### PR TITLE
feat(ci #9): adicionar workflow para buildar e empacotar projeto Java 17

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
         run: mvn clean package -DskipTests=true
 
       - name: Upload do Arquivo
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@latest
         with:
            name: 'app.jar'
            path: 'target/*.jar'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Configurar o Java 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,31 @@
+name: Buildar e Empacotar o Projeto
+
+on:
+  push:
+    branches: [ main, develop ]
+  pull_request:
+    branches: [ main, develop ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout do respositorio
+        uses: actions/checkout@v2
+
+      - name: Configurar o Java 17
+        uses: actions/setup-java@v2
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Executar o Maven sem testes
+        run: mvn clean package -DskipTests=true
+
+      - name: Upload do Arquivo
+        uses: actions/upload-artifact@v2
+        with:
+           name: 'app.jar'
+           path: 'target/*.jar'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
         run: mvn clean package -DskipTests=true
 
       - name: Upload do Arquivo
-        uses: actions/upload-artifact@latest
+        uses: actions/upload-artifact@v4
         with:
            name: 'app.jar'
            path: 'target/*.jar'


### PR DESCRIPTION
Adicionado workflow GitHub Actions (maven-build.yml) responsável por buildar e empacotar o projeto Java 17 utilizando Maven.

- Executa automaticamente em push e pull request nos branches main e develop
- Configura ambiente com Java 17 (Temurin)
- Realiza build com Maven ignorando testes (-DskipTests)
- Faz upload do arquivo .jar gerado como artefato 'app.jar'

Esse workflow garante que o build seja validado e empacotado de forma contínua durante o desenvolvimento.